### PR TITLE
fix asyncio import in python3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 sudo: false
 language: python
 matrix:
@@ -6,7 +6,8 @@ matrix:
     - python: "3.4"
     - python: "3.5"
     - python: "3.6"
-    - python: pypy3.5-5.8.0
+    - python: "3.7"
+    - python: pypy3.5-7.0.0
 cache:
   - pip
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 language: python
 matrix:
   include:
-    - python: "3.4"
     - python: "3.5"
     - python: "3.6"
     - python: "3.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
     - python: "3.5"
     - python: "3.6"
     - python: "3.7"
-    - python: pypy3.5-7.0.0
+    - python: pypy3.5-6.0
 cache:
   - pip
 install:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,0 @@
-pytest
-pytest-asyncio~=0.5.0; python_version < '3.6'
-pytest-asyncio; python_version >= '3.6'
-pytest-xdist
-coverage
-flake8
-tox

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,25 @@ from setuptools import setup, find_packages
 
 VERSION = '0.1'
 
+install_requires = [
+    'pyyaml',
+    'Jinja2',
+    'boto3',
+    'aiofiles',
+    'click',
+]
+
+extras_require = {
+    'testing': [
+        'pytest',
+        'pytest-asyncio>=0.6.0',
+        'pytest-xdist',
+        'coverage',
+        'flake8',
+        'tox',
+    ]
+}
+
 setup(
     name='shelver',
     packages=find_packages(),
@@ -13,12 +32,7 @@ setup(
     author='Daniel Miranda',
     author_email='daniel@cobli.co',
     license='MPL2',
-    install_requires=[
-        'pyyaml',
-        'Jinja2',
-        'boto3',
-        'aiofiles',
-        'click'
-    ],
+    install_requires=install_requires,
+    extras_require=extras_require,
     scripts=['bin/shelver'],
     keywords='packer aws ami cloud cd continuous-deployment')

--- a/shelver/archive/file_lock.py
+++ b/shelver/archive/file_lock.py
@@ -9,12 +9,11 @@ class FileLock(AsyncBase):
         super().__init__(**kwargs)
         self._file = file
 
-    @asyncio.coroutine
-    def acquire(self, exclusive=True, *, timeout=None):
+    async def acquire(self, exclusive=True, *, timeout=None):
         flags = fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH
         do_lock = self.delay(fcntl.flock, self._file, flags)
 
-        yield from asyncio.wait_for(do_lock, timeout, loop=self._loop)
+        await asyncio.wait_for(do_lock, timeout, loop=self._loop)
         return self._file
 
     def release(self):

--- a/shelver/build/coordinator.py
+++ b/shelver/build/coordinator.py
@@ -1,10 +1,9 @@
 import asyncio
 import logging
 from functools import partial
-try:
-    from asyncio import ensure_future
-except ImportError:
-    from asyncio import async as ensure_future
+ensure_future = getattr(asyncio, "ensure_future", None)
+if not ensure_future:
+    ensure_future = getattr(asyncio, "async")
 
 import yaml
 from shelver.errors import ConfigurationError, PackerError, ShelverError

--- a/shelver/cli.py
+++ b/shelver/cli.py
@@ -8,10 +8,6 @@ from collections import namedtuple
 from fnmatch import fnmatch
 from functools import wraps
 from asyncio.futures import CancelledError, TimeoutError
-try:
-    from asyncio import ensure_future
-except ImportError:
-    from asyncio import async as ensure_future
 
 import yaml
 import click
@@ -20,6 +16,10 @@ from shelver.build import Builder
 from shelver.image import Image
 from shelver.errors import ShelverError
 from shelver.util import AsyncLoopSupervisor
+
+ensure_future = getattr(asyncio, "ensure_future", None)
+if not ensure_future:
+    ensure_future = getattr(asyncio, "async")
 
 
 logger = logging.getLogger('shelver.cli')

--- a/shelver/provider/test.py
+++ b/shelver/provider/test.py
@@ -1,5 +1,4 @@
 import logging
-import asyncio
 
 from shelver.artifact import Artifact
 from shelver.registry import Registry
@@ -21,8 +20,7 @@ class TestArtifact(Artifact):
 
 
 class TestRegistry(Registry):
-    @asyncio.coroutine
-    def load_artifact_by_id(self, id, region=None, image=None):
+    async def load_artifact_by_id(self, id, region=None, image=None):
         name, version = id.split(':')
         if not image:
             image = self.get_image(name)
@@ -33,14 +31,13 @@ class TestRegistry(Registry):
         self.associate_artifact(artifact, image, version)
         return artifact
 
-    @asyncio.coroutine
-    def load_existing_artifacts(self, region=None):
+    async def load_existing_artifacts(self, region=None):
         pass
 
 
 class TestBuilder(Builder):
-    @asyncio.coroutine
-    def run_build(self, image, version, base_artifact=None, msg_stream=None):
+    async def run_build(self, image, version, base_artifact=None,
+                        msg_stream=None):
         image = self.registry.get_image(image)
         if not version:
             version = image.current_version

--- a/shelver/registry.py
+++ b/shelver/registry.py
@@ -1,4 +1,3 @@
-import asyncio
 from abc import ABCMeta, abstractmethod
 from collections import defaultdict
 
@@ -108,13 +107,11 @@ class Registry(AsyncBase, metaclass=ABCMeta):
         return self
 
     @abstractmethod
-    @asyncio.coroutine
-    def load_existing_artifacts(self, region=None):
+    async def load_existing_artifacts(self, region=None):
         pass
 
     @abstractmethod
-    @asyncio.coroutine
-    def load_artifact_by_id(self, id, region=None, image=None):
+    async def load_artifact_by_id(self, id, region=None, image=None):
         pass
 
     def get_image_artifact(self, image, version=None,

--- a/shelver/test/test_util_async.py
+++ b/shelver/test/test_util_async.py
@@ -6,7 +6,7 @@ import signal
 try:
     from asyncio import ensure_future
 except ImportError:
-    from asyncio import async as ensure_future
+    ensure_future = getattr(asyncio, 'async')
 
 import pytest
 from shelver.util import AsyncBase, AsyncLoopSupervisor

--- a/shelver/test/test_util_async.py
+++ b/shelver/test/test_util_async.py
@@ -3,10 +3,8 @@ import asyncio
 import threading
 import time
 import signal
-try:
-    from asyncio import ensure_future
-except ImportError:
-    ensure_future = getattr(asyncio, 'async')
+
+from asyncio import ensure_future
 
 import pytest
 from shelver.util import AsyncBase, AsyncLoopSupervisor
@@ -27,7 +25,7 @@ def test_async_base_init_explicit(event_loop):
 
 
 @pytest.mark.asyncio
-def test_async_base_delay(event_loop):
+async def test_async_base_delay(event_loop):
     async_obj = AsyncBase(loop=event_loop)
 
     # Run a sleep in the background with delay, get the time in a second
@@ -38,7 +36,7 @@ def test_async_base_delay(event_loop):
 
     f = ensure_future(async_obj.delay(get_time))
     t1 = event_loop.time()
-    t2 = yield from f
+    t2 = await f
 
     # If running get_time() blocked, it would have finished before running the
     # subsequent lines, making t2 >= t1.
@@ -56,12 +54,12 @@ def test_async_loop_supervisor_init(event_loop):
     assert supervisor.timeout == 10
 
 
-def _count_cancellations(timeout, times=1, loop=None):
+async def _count_cancellations(timeout, times=1, loop=None):
     cancel_count = 0
 
     for _ in range(times):
         try:
-            yield from asyncio.sleep(timeout, loop=loop)
+            await asyncio.sleep(timeout, loop=loop)
         except asyncio.CancelledError:
             cancel_count += 1
 

--- a/shelver/util.py
+++ b/shelver/util.py
@@ -3,10 +3,10 @@ import asyncio
 from itertools import chain
 from collections import Hashable, Iterable, Mapping, MutableMapping, Set, deque
 from signal import SIGHUP, SIGINT
-try:
-    from asyncio import ensure_future
-except ImportError:
-    from asyncio import async as ensure_future
+
+ensure_future = getattr(asyncio, "ensure_future", None)
+if not ensure_future:
+    ensure_future = getattr(asyncio, "async")
 
 
 class FrozenDict(Mapping):  # pragma: nocover

--- a/shelver/util.py
+++ b/shelver/util.py
@@ -1,12 +1,11 @@
 import subprocess
 import asyncio
-from itertools import chain
-from collections import Hashable, Iterable, Mapping, MutableMapping, Set, deque
-from signal import SIGHUP, SIGINT
 
-ensure_future = getattr(asyncio, "ensure_future", None)
-if not ensure_future:
-    ensure_future = getattr(asyncio, "async")
+from asyncio import ensure_future
+from collections import deque
+from collections.abc import Hashable, Iterable, Mapping, MutableMapping, Set
+from itertools import chain
+from signal import SIGHUP, SIGINT
 
 
 class FrozenDict(Mapping):  # pragma: nocover
@@ -222,17 +221,17 @@ def topological_sort(nodes, edges):
     return result
 
 
-@asyncio.coroutine
-def async_subprocess_run(program, *args, input=None, stdout=subprocess.PIPE,
-                         stderr=None, loop=None, limit=None, **kwargs):
+async def async_subprocess_run(program, *args, input=None,
+                               stdout=subprocess.PIPE, stderr=None, loop=None,
+                               limit=None, **kwargs):
     loop = loop or asyncio.get_event_loop()
     cmd = [program] + list(args)
 
     limit = limit or 2 ** 32
-    proc = yield from asyncio.create_subprocess_exec(
+    proc = await asyncio.create_subprocess_exec(
         *cmd, stdout=stdout, stderr=stderr, loop=loop, limit=limit, **kwargs)
-    out, err = yield from proc.communicate(input)
-    ret = yield from proc.wait()
+    out, err = await proc.communicate(input)
+    ret = await proc.wait()
 
     if ret != 0:
         exc = subprocess.CalledProcessError(ret, cmd, output=out)

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,13 @@
 [tox]
 envlist =
-    py34
     py35
     py36
+    py37
     pypy3
-toxworkdir = {env:TOXWORKDIR:}
+toxworkdir = {env:TOXWORKDIR:{toxinidir}/.tox}
 
 [testenv]
 whitelist_externals = true
-deps =
-    -rrequirements-dev.txt
+extras = testing
 commands =
     ./test.sh


### PR DESCRIPTION
As async is a reserved word in python 3.7 we need to import it in a different way.
We follow the suggestion in this [discussion thread](https://www.redhat.com/archives/libvir-list/2018-June/msg01632.html).
