### PR TITLE
fix a bug with click 8 version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ install_requires = [
     'Jinja2',
     'boto3',
     'aiofiles',
-    'click',
+    'click<8',
 ]
 
 extras_require = {


### PR DESCRIPTION
For some unknown reason, packer_cmd argument is reaching as a list inside those `self.instream` variable.

This error does not occurs on click 7.1.2.

I'm blocking click version upgrade for now.

```
shelver -p aws -c shelver.yml -d . build xxxx
DEBUG:asyncio:Using selector: EpollSelector
Traceback (most recent call last):
  File "/home/ivan/Projects/Cobliteam/ansible/venv/bin/shelver", line 7, in <module>
    exec(compile(f.read(), __file__, 'exec'))
  File "/home/ivan/Projects/Cobliteam/ansible/venv/src/shelver/bin/shelver", line 5, in <module>
    sys.exit(main())
  File "/home/ivan/Projects/Cobliteam/ansible/venv/lib/python3.8/site-packages/click/core.py", line 1137, in __call__
    return self.main(*args, **kwargs)
  File "/home/ivan/Projects/Cobliteam/ansible/venv/lib/python3.8/site-packages/click/core.py", line 1062, in main
    rv = self.invoke(ctx)
  File "/home/ivan/Projects/Cobliteam/ansible/venv/lib/python3.8/site-packages/click/core.py", line 1666, in invoke
    sub_ctx = cmd.make_context(cmd_name, args, parent=ctx)
  File "/home/ivan/Projects/Cobliteam/ansible/venv/lib/python3.8/site-packages/click/core.py", line 923, in make_context
    self.parse_args(ctx, args)
  File "/home/ivan/Projects/Cobliteam/ansible/venv/lib/python3.8/site-packages/click/core.py", line 1379, in parse_args
    value, args = param.handle_parse_result(ctx, opts, args)
  File "/home/ivan/Projects/Cobliteam/ansible/venv/lib/python3.8/site-packages/click/core.py", line 2364, in handle_parse_result
    value = self.process_value(ctx, value)
  File "/home/ivan/Projects/Cobliteam/ansible/venv/lib/python3.8/site-packages/click/core.py", line 2320, in process_value
    value = self.type_cast_value(ctx, value)
  File "/home/ivan/Projects/Cobliteam/ansible/venv/lib/python3.8/site-packages/click/core.py", line 2307, in type_cast_value
    return convert(value)
  File "/home/ivan/Projects/Cobliteam/ansible/venv/lib/python3.8/site-packages/click/types.py", line 75, in __call__
    return self.convert(value, param, ctx)
  File "/home/ivan/Projects/Cobliteam/ansible/venv/lib/python3.8/site-packages/click/types.py", line 170, in convert
    return self.func(value)
  File "/usr/lib/python3.8/shlex.py", line 311, in split
    return list(lex)
  File "/usr/lib/python3.8/shlex.py", line 300, in __next__
    token = self.get_token()
  File "/usr/lib/python3.8/shlex.py", line 109, in get_token
    raw = self.read_token()
  File "/usr/lib/python3.8/shlex.py", line 140, in read_token
    nextchar = self.instream.read(1)
AttributeError: 'list' object has no attribute 'read'
```